### PR TITLE
0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.3
+* Fixed bug when cleaning up after a failed `git merge`
+* Exit out of `papa [hotfix, release] finish` when one of the base branches fails to be merged on
+
 ## 0.6.2
 * Reset build branch from origin every time a new branch is added
 

--- a/lib/papa/command/git/merge.rb
+++ b/lib/papa/command/git/merge.rb
@@ -17,6 +17,9 @@ module Papa
 
         def cleanup
           super
+          require 'papa/command/git/merge_abort'
+          require 'papa/command/git/checkout'
+
           Command::Git::MergeAbort.new.run
           Command::Git::Checkout.new(current_branch).run
         end

--- a/lib/papa/task/common/finish.rb
+++ b/lib/papa/task/common/finish.rb
@@ -1,6 +1,7 @@
 require 'papa/command/git/fetch'
 require 'papa/command/git/checkout'
 require 'papa/command/git/merge'
+require 'papa/command/git/reset_hard'
 require 'papa/command/git/push'
 require 'papa/command/git/tag'
 require 'papa/command/git/tag_push'
@@ -25,16 +26,12 @@ module Papa
             if runner.run
               @success_branches << branch
             else
-              success = false
+              failure_message
+              exit 1
             end
           end
 
-          if success
-            success_message
-          else
-            failure_message
-            exit 1
-          end
+          success_message
         end
 
         private
@@ -54,6 +51,7 @@ module Papa
           queue = [
             Command::Git::Checkout.new(@build_branch),
             Command::Git::Checkout.new(branch),
+            Command::Git::ResetHard.new('origin', branch),
             Command::Git::Merge.new(@build_branch),
             Command::Git::Push.new('origin', branch)
           ]

--- a/lib/papa/version.rb
+++ b/lib/papa/version.rb
@@ -1,3 +1,3 @@
 module Papa
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
* Fixed bug when cleaning up after a failed `git merge`
* Exit out of `papa [hotfix, release] finish` when one of the base branches fails to be merged on