### PR TITLE
0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2
+* Change log file file format to `{TIMESTAMP}_papa_{BUILD_TYPE}_{COMMAND}.log`
+* Disallow the use of `papa [hotfix, release] add` with release and hotfix branches
+
 ## 0.7.1
 * Add ability to specify subdomain/hostname when deploying integration branches
 * Fetch only once when adding feature or bugfix branches to an integration branch

--- a/lib/papa/helper/logger.rb
+++ b/lib/papa/helper/logger.rb
@@ -11,7 +11,7 @@ module Papa
         return @log_path if defined?(@log_path)
         command = ARGV.first(2).join('_')
         timestamp = Time.now.strftime('%Y_%m_%d_%I_%M_%S')
-        @log_path = ['papa', command, timestamp].join('_') + '.log'
+        @log_path = [timestamp, 'papa', command].join('_') + '.log'
       end
     end
   end

--- a/lib/papa/task/common/add.rb
+++ b/lib/papa/task/common/add.rb
@@ -13,6 +13,7 @@ module Papa
         def initialize
           check_if_build_branch_exists
           check_if_branches_are_given
+          check_if_branches_are_valid
           @success_branches = []
           @failed_branches = []
         end
@@ -24,6 +25,18 @@ module Papa
           require 'papa/helper/vi'
           vi_file_helper = Helper::Vi.new
           @branches = vi_file_helper.run
+        end
+
+        def check_if_branches_are_valid
+          invalid_branch_prefixes = ['hotfix', 'release']
+          @branches.each do |branch|
+            has_invalid_branches = invalid_branch_prefixes.any? do |invalid_branch_prefix|
+              branch.start_with?(invalid_branch_prefix)
+            end
+            return unless has_invalid_branches
+            Helper::Output.failure "Branch #{branch.bold} cannot be added to #{@build_type.bold} build branches."
+            exit 1
+          end
         end
 
         def perform_task

--- a/lib/papa/version.rb
+++ b/lib/papa/version.rb
@@ -1,3 +1,3 @@
 module Papa
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end


### PR DESCRIPTION
* Change log file file format to `{TIMESTAMP}_papa_{BUILD_TYPE}_{COMMAND}.log`
* Disallow the use of `papa [hotfix, release] add` with release and hotfix branches
